### PR TITLE
Update snapcraft.yaml

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -12,6 +12,10 @@ description: |
   as mobile (Android, iOS) and web-based (HTML5) platforms..
 confinement: strict
 
+architectures:
+  - build-on: i386
+  - build-on: amd64
+
 apps:
   godot:
     command: desktop-launch $SNAP/bin/Godot


### PR DESCRIPTION
Ensure we don't waste build time on the builders, by only trying to build on amd64 and i386.